### PR TITLE
Add choice nodes to resolve inconsistence between fuselage guide curves and kinks

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -17708,14 +17708,24 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                             </xsd:element>
                         </xsd:sequence>
                         <xsd:sequence>
-                            <xsd:element name="fromRelativeCircumference" type="doubleBaseType">
-                                <xsd:annotation>
-                                    <xsd:documentation>Reference to the relative circumference
-                                        position from which the guide curve shall start. Valid values
-                                        are in the interval -1.0...1.0.
-                                    </xsd:documentation>
-                                </xsd:annotation>
-                            </xsd:element>
+                            <xsd:choice>
+                                <xsd:element name="fromRelativeCircumference" type="doubleBaseType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Reference to the relative circumference
+                                            position from which the guide curve shall start. Valid values
+                                            are in the interval -1.0...1.0.
+                                        </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="fromParameter" type="doubleBaseType">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Reference to the parameter
+                                            position from which the guide curve shall start. Valid values
+                                            are in the interval -1.0...1.0.
+                                            </xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                            </xsd:choice>
                             <xsd:element name="tangent" minOccurs="0" type="pointXYZType">
                                 <xsd:annotation>
                                     <xsd:documentation>Tangent at first point</xsd:documentation>
@@ -17724,14 +17734,24 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                         </xsd:sequence>
                     </xsd:choice>
                     <xsd:sequence>
-                        <xsd:element name="toRelativeCircumference" type="doubleBaseType">
-                            <xsd:annotation>
-                                <xsd:documentation>The relative circumference
-                                    position at which the guide curve shall end. Valid values
-                                    are in the interval -1,..,1.
-                                </xsd:documentation>
-                            </xsd:annotation>
-                        </xsd:element>
+                        <xsd:choice>
+                            <xsd:element name="toRelativeCircumference" type="doubleBaseType">
+                                <xsd:annotation>
+                                    <xsd:documentation>The relative circumference
+                                        position at which the guide curve shall end. Valid values
+                                        are in the interval -1.0,..,1.0.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                            <xsd:element name="toParameter" type="doubleBaseType">
+                                <xsd:annotation>
+                                    <xsd:documentation>The parameter
+                                        position at which the guide curve shall end. Valid values
+                                       are in the interval -1.0...1.0.
+                                    </xsd:documentation>
+                                </xsd:annotation>
+                            </xsd:element>
+                        </xsd:choice>
                         <xsd:element name="tangent" minOccurs="0" type="pointXYZType">
                             <xsd:annotation>
                                 <xsd:documentation>Tangent at last point</xsd:documentation>


### PR DESCRIPTION
Up to now, kinks and guide curves and not defined consistently. Guides are placed based on profile's arc length, kinks based on parameters on profile. With the new nodes, the user can more easily control the relative position to each other.

This PR introduces new choice nodes `fromParameter` and `toParameter` to possibly replace the existing nodes `fromRelativeCircumference` and `toRelativeCircumference`, respectively, depending on the user's choice.


Fixes #837 
Original issue from TiGL repo (https://github.com/DLR-SC/tigl/issues/745)