### PR TITLE
Use symmetryXyXzYzType for the symmetry attribute in ductType

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -12336,17 +12336,7 @@ cpacs@dlr.de
                     <xsd:element name="structure" minOccurs="0" type="ductStructureType"/>
                 </xsd:all>
                 <xsd:attribute name="uID" use="required" type="xsd:ID"/>
-                <xsd:attribute name="symmetry">
-                    <xsd:simpleType>
-                        <xsd:restriction base="xsd:string">
-                            <xsd:enumeration value="none"/>
-                            <xsd:enumeration value="inherit"/>
-                            <xsd:enumeration value="x-y-plane"/>
-                            <xsd:enumeration value="x-z-plane"/>
-                            <xsd:enumeration value="y-z-plane"/>
-                        </xsd:restriction>
-                    </xsd:simpleType>
-                </xsd:attribute>
+                <xsd:attribute name="symmetry" type="symmetryXyXzYzType"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>


### PR DESCRIPTION
We noticed a minor inconsistency in the symmetry attribute of the ductType while updating TiGL to CPACS 3.4. 

The ductType was created by us on the basis of CPACS 3.2 (I think) and therefore it does not include the changes provided in https://github.com/DLR-SL/CPACS/issues/735, where the symmetry attributes where changed to the new complexType `symmetryXyXzYzType`.

Related: https://github.com/DLR-SC/tigl/pull/1027