### PR TITLE
Loft continuity attribute

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -12336,17 +12336,8 @@ cpacs@dlr.de
                     <xsd:element name="structure" minOccurs="0" type="ductStructureType"/>
                 </xsd:all>
                 <xsd:attribute name="uID" use="required" type="xsd:ID"/>
-                <xsd:attribute name="symmetry">
-                    <xsd:simpleType>
-                        <xsd:restriction base="xsd:string">
-                            <xsd:enumeration value="none"/>
-                            <xsd:enumeration value="inherit"/>
-                            <xsd:enumeration value="x-y-plane"/>
-                            <xsd:enumeration value="x-z-plane"/>
-                            <xsd:enumeration value="y-z-plane"/>
-                        </xsd:restriction>
-                    </xsd:simpleType>
-                </xsd:attribute>
+                <xsd:attribute name="symmetry" type="symmetryXyXzYzType"/>
+                <xsd:attribute name="loftContinuity" type="loftContinuityType"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -34323,7 +34314,7 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
             <xsd:appinfo>
                 <sd:schemaDoc>
                     <ddue:summary>
-                        <ddue:para>Set continuity for lofting of this component (default for fuselages: C2, for wings: C0)</ddue:para>
+                        <ddue:para>Set continuity for lofting of this component (default for fuselages/ducts: C2, for wings: C0)</ddue:para>
                     </ddue:summary>
                 </sd:schemaDoc>
             </xsd:appinfo>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -20570,6 +20570,22 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
         </xsd:complexContent>
     </xsd:complexType>
 
+     <xsd:simpleType name="loftContinuityType">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <sd:schemaDoc>
+                    <ddue:summary>
+                        <ddue:para>Set continuity for lofting of this component (default for fuselages/ducts: C2, for wings: C0)</ddue:para>
+                    </ddue:summary>
+                </sd:schemaDoc>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="C0"/>
+            <xsd:enumeration value="C2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
     <xsd:complexType name="logEntryType">
         <xsd:annotation>
             <xsd:appinfo>
@@ -34306,22 +34322,6 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                     <xsd:documentation>Symmetry w.r.t. the y-z plane of the CPACS coordinate system</xsd:documentation>
                 </xsd:annotation>
             </xsd:enumeration>
-        </xsd:restriction>
-    </xsd:simpleType>
-
-    <xsd:simpleType name="loftContinuityType">
-        <xsd:annotation>
-            <xsd:appinfo>
-                <sd:schemaDoc>
-                    <ddue:summary>
-                        <ddue:para>Set continuity for lofting of this component (default for fuselages/ducts: C2, for wings: C0)</ddue:para>
-                    </ddue:summary>
-                </sd:schemaDoc>
-            </xsd:appinfo>
-        </xsd:annotation>
-        <xsd:restriction base="xsd:string">
-            <xsd:enumeration value="C0"/>
-            <xsd:enumeration value="C2"/>
         </xsd:restriction>
     </xsd:simpleType>
 

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -16454,6 +16454,14 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                 </xsd:all>
                 <xsd:attribute name="uID" use="required" type="xsd:ID"/>
                 <xsd:attribute name="symmetry" type="symmetryXyXzYzType"/>
+                <xsd:attribute name="loftContinuity">
+                    <xsd:simpleType>
+                        <xsd:restriction base="xsd:string">
+                            <xsd:enumeration value="C0"/>
+                            <xsd:enumeration value="C2"/>
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -39128,6 +39136,14 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                 </xsd:all>
                 <xsd:attribute name="uID" use="required" type="xsd:ID"/>
                 <xsd:attribute name="symmetry" type="symmetryXyXzYzType"/>
+                <xsd:attribute name="loftContinuity">
+                    <xsd:simpleType>
+                        <xsd:restriction base="xsd:string">
+                            <xsd:enumeration value="C0"/>
+                            <xsd:enumeration value="C2"/>
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:attribute>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -16454,14 +16454,7 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                 </xsd:all>
                 <xsd:attribute name="uID" use="required" type="xsd:ID"/>
                 <xsd:attribute name="symmetry" type="symmetryXyXzYzType"/>
-                <xsd:attribute name="loftContinuity">
-                    <xsd:simpleType>
-                        <xsd:restriction base="xsd:string">
-                            <xsd:enumeration value="C0"/>
-                            <xsd:enumeration value="C2"/>
-                        </xsd:restriction>
-                    </xsd:simpleType>
-                </xsd:attribute>
+                <xsd:attribute name="loftContinuity" type="loftContinuityType"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -34325,6 +34318,22 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
         </xsd:restriction>
     </xsd:simpleType>
 
+    <xsd:simpleType name="loftContinuityType">
+        <xsd:annotation>
+            <xsd:appinfo>
+                <sd:schemaDoc>
+                    <ddue:summary>
+                        <ddue:para>Set continuity for lofting of this component (default for fuselages: C2, for wings: C0)</ddue:para>
+                    </ddue:summary>
+                </sd:schemaDoc>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="C0"/>
+            <xsd:enumeration value="C2"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
     <xsd:complexType name="systemArchitecturesType">
         <xsd:annotation>
             <xsd:appinfo>
@@ -39136,14 +39145,7 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
                 </xsd:all>
                 <xsd:attribute name="uID" use="required" type="xsd:ID"/>
                 <xsd:attribute name="symmetry" type="symmetryXyXzYzType"/>
-                <xsd:attribute name="loftContinuity">
-                    <xsd:simpleType>
-                        <xsd:restriction base="xsd:string">
-                            <xsd:enumeration value="C0"/>
-                            <xsd:enumeration value="C2"/>
-                        </xsd:restriction>
-                    </xsd:simpleType>
-                </xsd:attribute>
+                <xsd:attribute name="loftContinuity" type="loftContinuityType"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -20570,7 +20570,7 @@ The fuel tank volume type should also be used for the wing fuel tank</xsd:docume
         </xsd:complexContent>
     </xsd:complexType>
 
-     <xsd:simpleType name="loftContinuityType">
+    <xsd:simpleType name="loftContinuityType">
         <xsd:annotation>
             <xsd:appinfo>
                 <sd:schemaDoc>


### PR DESCRIPTION
Currently the default lofting logic in TiGL is that fuselages and ducts are lofted with C2 continuity and wings with C0 continuity.

The proposed changes to CPACS add an optional attribute to the wingType, fuselageType and ductType that allows explicitly setting the continuity for the respective component.

If omitted, the defaults of TiGL as described above should be kept. If set, the default behaviour may be overruled.