### PR TITLE
Add new approximationSettings element to define profile approximation

### DIFF
--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -4714,6 +4714,55 @@ cpacs@dlr.de
         </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:complexType name="approximationSettingsType">
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:element name="controlPointNumber" default="12">
+                    <xsd:annotation>
+                        <xsd:documentation>Defines the number of control points that should be used for approximating the given points with a b-spline curve.</xsd:documentation>
+                    </xsd:annotation>
+                    <xsd:simpleType>
+                        <xsd:restriction base="integerBaseType">
+                            <xsd:minInclusive value="3"></xsd:minInclusive>
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:element>
+                <xsd:element name="maximumError" default="1e-5">
+                    <xsd:annotation>
+                        <xsd:documentation>Instead of specifying the number of control points, the upper bound for the error of the approximation is provided.
+                        The number of control points is increased automatically until the approximation error lies below the given maximum approximation error.
+                        </xsd:documentation>
+                    </xsd:annotation>
+                    <xsd:simpleType>
+                        <xsd:restriction base="doubleBaseType">
+                            <xsd:minExclusive value="0"></xsd:minExclusive>
+                        </xsd:restriction>
+                    </xsd:simpleType>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="interpolatedPointsIndices" maxOccurs="1" minOccurs="0" type="stringVectorBaseType">
+                <xsd:annotation>
+                    <xsd:documentation>Index list of points that should still be interpolated. Each index is in the range [1, npoints].
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="errorComputationMethod" default="RMSE">
+            <xsd:annotation>
+                <xsd:documentation>Here, the approximation error's computation method can be chosen. The error is computed between the defined points (A) and their respective projections on the approximated curve (B).
+                By default, this error is computed as the root mean square error of the distances between (A) and (B).
+                In the following, the currently allowed entries are listed together with their meaning (-> respective computation method):
+                    1. RMSE: Root Mean Square Error
+                    2. MaxError: Maximum Error
+                </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+    </xsd:complexType>
+
     <xsd:simpleType name="ataChapterListType">
         <xsd:annotation>
             <xsd:appinfo>
@@ -10768,6 +10817,13 @@ cpacs@dlr.de
                     <xsd:element name="parameterMap" minOccurs="0" type="curveParamPointMapType">
                         <xsd:annotation>
                             <xsd:documentation>Map between point index and curve parameter.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="approximationSettings" type="approximationSettingsType" maxOccurs="1" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>If this element is specified, the given point list is approximated instead of interpolated when creating a b-spline representation of the profile.
+                            This has the advantage of more control over the complexity of the resulting b-spline curves, but does not guarantee that the b-spline curve passes through all given points as for the interpolation approach introducing possible imprecisions in the geometrical representation of the profile.
+                            </xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
                 </xsd:sequence>

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -4717,27 +4717,17 @@ cpacs@dlr.de
     <xsd:complexType name="approximationSettingsType">
         <xsd:sequence>
             <xsd:choice>
-                <xsd:element name="controlPointNumber" default="12">
+                <xsd:element name="controlPointNumber" default="12" type="integerBaseType">
                     <xsd:annotation>
-                        <xsd:documentation>Defines the number of control points that should be used for approximating the given points with a b-spline curve.</xsd:documentation>
+                        <xsd:documentation>Defines the number of control points that should be used for approximating the given points with a B-spline curve. The minimal value is 3.</xsd:documentation>
                     </xsd:annotation>
-                    <xsd:simpleType>
-                        <xsd:restriction base="integerBaseType">
-                            <xsd:minInclusive value="3"></xsd:minInclusive>
-                        </xsd:restriction>
-                    </xsd:simpleType>
                 </xsd:element>
-                <xsd:element name="maximumError" default="1e-5">
+                <xsd:element name="maximumError" default="1e-5" type="doubleBaseType">
                     <xsd:annotation>
-                        <xsd:documentation>Instead of specifying the number of control points, the upper bound for the error of the approximation is provided.
+                        <xsd:documentation>Instead of specifying the number of control points, the positive upper bound for the error of the approximation is provided.
                         The number of control points is increased automatically until the approximation error lies below the given maximum approximation error.
                         </xsd:documentation>
                     </xsd:annotation>
-                    <xsd:simpleType>
-                        <xsd:restriction base="doubleBaseType">
-                            <xsd:minExclusive value="0"></xsd:minExclusive>
-                        </xsd:restriction>
-                    </xsd:simpleType>
                 </xsd:element>
             </xsd:choice>
             <xsd:element name="interpolatedPointsIndices" maxOccurs="1" minOccurs="0" type="stringVectorBaseType">

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -4721,30 +4721,30 @@ cpacs@dlr.de
                     <xsd:annotation>
                         <xsd:documentation>Defines the number of control points that should be used for approximating the given points with a B-spline curve. The minimal value is 3.</xsd:documentation>
                     </xsd:annotation>
-                    <xsd:complexType>
+                        <xsd:complexType>
                         <xsd:simpleContent>
                             <xsd:restriction base="integerBaseType">
-                                <xsd:minExclusive value="3"></xsd:minExclusive>
+                                <xsd:minExclusive value="3"/>
                             </xsd:restriction>
                         </xsd:simpleContent>
                     </xsd:complexType>
                 </xsd:element>
-				<xsd:element name="maximumError" default="1e-5">
+                <xsd:element name="maximumError" default="1e-5">
                     <xsd:annotation>
                         <xsd:documentation>Instead of specifying the number of control points, the positive upper bound for the error of the approximation is provided.
                         The number of control points is increased automatically until the approximation error lies below the given maximum approximation error.
                         </xsd:documentation>
                     </xsd:annotation>
-                    <xsd:complexType>
+                        <xsd:complexType>
                         <xsd:simpleContent>
                             <xsd:restriction base="doubleBaseType">
-                                <xsd:minExclusive value="0"></xsd:minExclusive>
+                                <xsd:minExclusive value="0"/>
                             </xsd:restriction>
                         </xsd:simpleContent>
                     </xsd:complexType>
                 </xsd:element>
             </xsd:choice>
-            <xsd:element name="interpolatedPointsIndices" maxOccurs="1" minOccurs="0" type="stringVectorBaseType">
+            <xsd:element name="interpolatedPointsIndices" minOccurs="0" type="stringVectorBaseType">
                 <xsd:annotation>
                     <xsd:documentation>Index list of points that should still be interpolated. Each index is in the range [1, npoints].
                     </xsd:documentation>
@@ -4755,7 +4755,7 @@ cpacs@dlr.de
             <xsd:annotation>
                 <xsd:documentation>Here, the approximation error's computation method can be chosen. The error is computed between the defined points (A) and their respective projections on the approximated curve (B).
                 By default, this error is computed as the root mean square error of the distances between (A) and (B).
-                In the following, the currently allowed entries are listed together with their meaning (-> respective computation method):
+                In the following, the currently allowed entries are listed together with their meaning (-&gt; respective computation method):
                     1. RMSE: Root Mean Square Error
                     2. MaxError: Maximum Error
                 </xsd:documentation>
@@ -10823,7 +10823,7 @@ cpacs@dlr.de
                             <xsd:documentation>Map between point index and curve parameter.</xsd:documentation>
                         </xsd:annotation>
                     </xsd:element>
-                    <xsd:element name="approximationSettings" type="approximationSettingsType" maxOccurs="1" minOccurs="0">
+                    <xsd:element name="approximationSettings" minOccurs="0" type="approximationSettingsType">
                         <xsd:annotation>
                             <xsd:documentation>If this element is specified, the given point list is approximated instead of interpolated when creating a b-spline representation of the profile.
                             This has the advantage of more control over the complexity of the resulting b-spline curves, but does not guarantee that the b-spline curve passes through all given points as for the interpolation approach introducing possible imprecisions in the geometrical representation of the profile.

--- a/schema/cpacs_schema.xsd
+++ b/schema/cpacs_schema.xsd
@@ -4717,17 +4717,31 @@ cpacs@dlr.de
     <xsd:complexType name="approximationSettingsType">
         <xsd:sequence>
             <xsd:choice>
-                <xsd:element name="controlPointNumber" default="12" type="integerBaseType">
+                <xsd:element name="controlPointNumber" default="12">
                     <xsd:annotation>
                         <xsd:documentation>Defines the number of control points that should be used for approximating the given points with a B-spline curve. The minimal value is 3.</xsd:documentation>
                     </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:simpleContent>
+                            <xsd:restriction base="integerBaseType">
+                                <xsd:minExclusive value="3"></xsd:minExclusive>
+                            </xsd:restriction>
+                        </xsd:simpleContent>
+                    </xsd:complexType>
                 </xsd:element>
-                <xsd:element name="maximumError" default="1e-5" type="doubleBaseType">
+				<xsd:element name="maximumError" default="1e-5">
                     <xsd:annotation>
                         <xsd:documentation>Instead of specifying the number of control points, the positive upper bound for the error of the approximation is provided.
                         The number of control points is increased automatically until the approximation error lies below the given maximum approximation error.
                         </xsd:documentation>
                     </xsd:annotation>
+                    <xsd:complexType>
+                        <xsd:simpleContent>
+                            <xsd:restriction base="doubleBaseType">
+                                <xsd:minExclusive value="0"></xsd:minExclusive>
+                            </xsd:restriction>
+                        </xsd:simpleContent>
+                    </xsd:complexType>
                 </xsd:element>
             </xsd:choice>
             <xsd:element name="interpolatedPointsIndices" maxOccurs="1" minOccurs="0" type="stringVectorBaseType">


### PR DESCRIPTION
This PR adds a new element to the XSD which lets the user define profile approximation instead of exact interpolation.
Here, it is possible to choose between to different ways: The user can either define the 
- number of control points that the B-spline consists of or
- maximum allowed error tolerance compard to exact interpolation.

Additionally, a index vector can be passed for both ways to list indices of the very points that should still be interpolated. Also, it is possible to define the error computation method. Right now, this is either the 'Root Mean Squared Error' or the 'Maximum Error'.

FIxes #863.